### PR TITLE
Minor type tweaks and linter fixes

### DIFF
--- a/python/faery/cli/process.py
+++ b/python/faery/cli/process.py
@@ -1,4 +1,5 @@
 import argparse
+import collections.abc
 import functools
 import sys
 import typing
@@ -616,7 +617,7 @@ class StreamWrapper:
             raise Exception(f'unexpected parent class "{parent_class}"')
 
 
-def split_on_keywords(arguments: list[str]) -> typing.Iterator[list[str]]:
+def split_on_keywords(arguments: list[str]) -> collections.abc.Iterator[list[str]]:
     subcommand_start_index = 0
     for index, argument in enumerate(arguments):
         if index > 0:

--- a/python/faery/event_camera_input.py
+++ b/python/faery/event_camera_input.py
@@ -1,3 +1,4 @@
+import collections.abc
 import importlib.util
 import logging
 import typing
@@ -48,7 +49,7 @@ class EventCameraDriverStream(events_stream.EventsStream):
             logging.info("No camera found using libcaer")
             raise e
 
-    def __iter__(self) -> typing.Iterator[np.ndarray]:
+    def __iter__(self) -> collections.abc.Iterator[np.ndarray]:
         logging.info(f"Starting streaming from event_camera_drivers: {self.camera}")
         while self.camera.is_running():
             v = next(self.camera)
@@ -61,7 +62,7 @@ class EventCameraDriverStream(events_stream.EventsStream):
 class NeuromorphicCameraStream(events_stream.EventsStream):
     def __init__(self):
         try:
-            import neuromorphic_drivers as nd
+            import neuromorphic_drivers as nd  # type: ignore
 
             self.nd = nd
             self.device_list = nd.list_devices()
@@ -76,7 +77,7 @@ class NeuromorphicCameraStream(events_stream.EventsStream):
         except Exception as e:
             raise e
 
-    def __iter__(self) -> typing.Iterator[np.ndarray]:
+    def __iter__(self) -> collections.abc.Iterator[np.ndarray]:
         logging.info(
             f"Starting streaming from neuromorphic_drivers: {self.device_list[0]}"
         )


### PR DESCRIPTION
typing.Iterable was deprecated in version 3.9 in favour of collections.abc.Iterable (https://docs.python.org/3/library/typing.html).