### PR TITLE
UDP bug fix and minor interface refactor, fix CLI `filter` and `view` command

### DIFF
--- a/python/faery/cli/list_filters.py
+++ b/python/faery/cli/list_filters.py
@@ -297,6 +297,10 @@ def class_to_name_to_filter() -> dict[typing.Any, dict[str, Filter]]:
                     str(faery.Time),
                     typing.Optional[faery.Time],
                     str(typing.Optional[faery.Time]),
+                    faery.TimeOrTimecode,
+                    str(faery.TimeOrTimecode),
+                    typing.Optional[faery.TimeOrTimecode],
+                    str(typing.Optional[faery.TimeOrTimecode]),
                     faery.Color,
                     str(faery.Color),
                     typing.Optional[faery.Color],
@@ -312,6 +316,18 @@ def class_to_name_to_filter() -> dict[typing.Any, dict[str, Filter]]:
                     elif parameter.annotation in {
                         typing.Optional[faery.Time],
                         str(typing.Optional[faery.Time]),
+                    }:
+                        options["type"] = parse_optional_time
+                        type_representation = "(int | float | hh:mm:ss.µµµµµµ | none)"
+                    elif parameter.annotation in {
+                        faery.TimeOrTimecode,
+                        str(faery.TimeOrTimecode),
+                    }:
+                        options["type"] = parse_time
+                        type_representation = "(int | float | hh:mm:ss.µµµµµµ)"
+                    elif parameter.annotation in {
+                        typing.Optional[faery.TimeOrTimecode],
+                        str(typing.Optional[faery.TimeOrTimecode]),
                     }:
                         options["type"] = parse_optional_time
                         type_representation = "(int | float | hh:mm:ss.µµµµµµ | none)"

--- a/python/faery/cli/process.py
+++ b/python/faery/cli/process.py
@@ -418,7 +418,20 @@ def output_parser(
 
         # Output frame viewer (GUI)
         subparser = subparsers.add_parser("view")
-        
+        if stream_parent_class in {
+            faery.FiniteFrameStream,
+            faery.FiniteRegularFrameStream,
+        }:
+            subparser.add_argument(
+                "--no-progress",
+                action="store_const",
+                const=False,
+                default=True,
+                dest="progress",
+            )
+        else:
+            subparser.add_argument("--progress", action="store_true")
+
         # Output frame files (frame collection)
         subparser = subparsers.add_parser("files")
         subparser.add_argument("path_pattern", metavar="path-pattern")
@@ -594,7 +607,8 @@ class StreamWrapper:
                 )
                 self.stream.to_files(**args)
             elif output == "view":
-                self.stream.to_viewer()
+                del args["on_progress"]
+                self.stream.view()
             else:
                 raise Exception(f'unknown output type "{output}"')
         else:

--- a/python/faery/cli/process.py
+++ b/python/faery/cli/process.py
@@ -316,9 +316,10 @@ def output_parser(
         subparser = subparsers.add_parser("udp")
         subparser.add_argument("address", type=list_filters.parse_udp)
         subparser.add_argument(
-            "--payload-length",
+            "--events-per-packet",
             type=list_filters.parse_optional_int,
             default="none",
+            dest="events_per_packet",
             help="(default: %(default)s)",
         )
         subparser.add_argument(

--- a/python/faery/events_stream.py
+++ b/python/faery/events_stream.py
@@ -184,7 +184,7 @@ class Output(typing.Generic[OutputState]):
         address: typing.Union[
             tuple[str, int], tuple[str, int, typing.Optional[int], typing.Optional[str]]
         ],
-        payload_length: typing.Optional[int] = None,
+        events_per_packet: typing.Optional[int] = None,
         format: enums.UdpFormat = "t64_x16_y16_on8",
         on_progress: typing.Callable[[OutputState], None] = lambda _: None,
     ) -> None:
@@ -192,28 +192,24 @@ class Output(typing.Generic[OutputState]):
         Sends the stream to the given UDP address and port.
 
         The address format defines whether IPv4 or IPv6 is used. If it has two items (host, port),
-        IPv4 is used. It it has four items (host, port, flowinfo, scope_id), IPv6 is used.
-        To force IPv6 but ommit scope_id and/or flowinfo, set them to None.
+        IPv4 is used. It has four items (host, port, flowinfo, scope_id), IPv6 is used.
+        To force IPv6 but omit scope_id and/or flowinfo, set them to None.
         See https://docs.python.org/3/library/socket.html for details.
 
-        To maximize throughput, consider re-arranging the stream in packets of exactly `payload_length / format_size` events
-        with `.chunks(payload_length / format_size)`. By default:
-        - for format "t64_x16_y16_on8", payload_length is 1209 and payload size is 13.
-        - for format "t32_x16_y15_on1", payload_length is 1208 and payload size is 8.
+        To maximize throughput, consider re-arranging the stream in packets of exactly `events_per_packet` events
+        with `.chunks(events_per_packet)`.
 
         Args:
             address: the UDP address as (host, port) for IPv4 and (host, port, flowinfo, scope_id) for IPv6.
-            payload_length: maximum payload size in bytes. It must be a multiple of the event size
-            (13 for format="t64_x16_y16_on8" and 8 for format="t64_x16_y16_on8"). Defaults to 1209 if format is "t64_x16_y16_on8"
-            and 1208 if format is "t32_x16_y15_on1".
-            format: Event encoding format. Defaults to "t64_x16_y16_on8".
+            events_per_packet: number of events per UDP packet. Defaults to 100 for both formats.
+            format: Event encoding format, either "t64_x16_y16_on8" or "t32_x16_y15_on1". Defaults to "t64_x16_y16_on8".
         """
         from . import udp_encoder
 
         return udp_encoder.encode(
             stream=self,
             address=address,
-            payload_length=payload_length,
+            events_per_packet=events_per_packet,
             format=format,
             on_progress=on_progress,  # type: ignore
         )

--- a/python/faery/udp_decoder.py
+++ b/python/faery/udp_decoder.py
@@ -99,6 +99,7 @@ class Decoder(events_stream.EventsStream):
                             previous_t = events["t"][-1]
                             yield events
         elif self.format == "t32_x16_y15_on1":
+            offset = 0
             with Receiver(self.address) as receiver:
                 dtype = numpy.dtype([("t", "<u4"), ("x", "<u2"), ("y+on", "<u2")])
                 while True:
@@ -115,7 +116,7 @@ class Decoder(events_stream.EventsStream):
                         events["t"] = raw_events["t"]
                         events["x"] = raw_events["x"]
                         events["y"] = raw_events["y+on"] >> 1
-                        events["y"] = raw_events["on"] & 1
+                        events["on"] = raw_events["y+on"] & 1
                         events["t"] += offset
                         if events["t"][0] >= previous_t:
                             previous_t = events["t"][-1]

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -1,8 +1,9 @@
-import pytest
 import threading
 import time
 
 import numpy as np
+import pytest
+
 import faery
 
 
@@ -35,9 +36,7 @@ def test_udp_encoder_decoder(format_type, events_per_packet, num_events, port):
         nonlocal receiver_exception
         try:
             stream = faery.events_stream_from_udp(
-                dimensions=dimensions,
-                address=address,
-                format=format_type
+                dimensions=dimensions, address=address, format=format_type
             )
             for events in stream:
                 received_events.append(events.copy())
@@ -50,11 +49,7 @@ def test_udp_encoder_decoder(format_type, events_per_packet, num_events, port):
         """Send test events via UDP."""
         time.sleep(0.2)  # Give receiver time to start listening
         stream = faery.events_stream_from_array(test_events, dimensions)
-        stream.to_udp(
-            address,
-            format=format_type,
-            events_per_packet=events_per_packet
-        )
+        stream.to_udp(address, format=format_type, events_per_packet=events_per_packet)
         time.sleep(0.1)  # Give receiver time to collect all packets
         stop_receiver.set()
 
@@ -74,25 +69,37 @@ def test_udp_encoder_decoder(format_type, events_per_packet, num_events, port):
 
     # Verify event count
     all_received = np.concatenate(received_events)
-    assert len(all_received) == num_events, (
-        f"Expected {num_events} events, got {len(all_received)}"
-    )
+    assert (
+        len(all_received) == num_events
+    ), f"Expected {num_events} events, got {len(all_received)}"
 
     # Verify event data matches (with consideration for timestamp wraparound in t32 format)
     if format_type == "t64_x16_y16_on8":
         # For t64 format, all fields should match exactly
-        assert np.array_equal(all_received["x"], test_events["x"]), "X coordinates don't match"
-        assert np.array_equal(all_received["y"], test_events["y"]), "Y coordinates don't match"
-        assert np.array_equal(all_received["on"], test_events["on"]), "Polarity doesn't match"
-        assert np.array_equal(all_received["t"], test_events["t"]), "Timestamps don't match"
+        assert np.array_equal(
+            all_received["x"], test_events["x"]
+        ), "X coordinates don't match"
+        assert np.array_equal(
+            all_received["y"], test_events["y"]
+        ), "Y coordinates don't match"
+        assert np.array_equal(
+            all_received["on"], test_events["on"]
+        ), "Polarity doesn't match"
+        assert np.array_equal(
+            all_received["t"], test_events["t"]
+        ), "Timestamps don't match"
     else:
         # For t32 format, timestamps are 32-bit so we check modulo 2^32
-        assert np.array_equal(all_received["x"], test_events["x"]), "X coordinates don't match"
-        assert np.array_equal(all_received["y"], test_events["y"]), "Y coordinates don't match"
-        assert np.array_equal(all_received["on"], test_events["on"]), "Polarity doesn't match"
+        assert np.array_equal(
+            all_received["x"], test_events["x"]
+        ), "X coordinates don't match"
+        assert np.array_equal(
+            all_received["y"], test_events["y"]
+        ), "Y coordinates don't match"
+        assert np.array_equal(
+            all_received["on"], test_events["on"]
+        ), "Polarity doesn't match"
         # Check timestamps modulo 2^32
         assert np.array_equal(
-            all_received["t"] & 0xFFFFFFFF,
-            test_events["t"] & 0xFFFFFFFF
+            all_received["t"] & 0xFFFFFFFF, test_events["t"] & 0xFFFFFFFF
         ), "Timestamps don't match"
-

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -7,13 +7,13 @@ import faery
 
 
 @pytest.mark.parametrize(
-    "format_type,payload_length,num_events,port",
+    "format_type,events_per_packet,num_events,port",
     [
-        ("t64_x16_y16_on8", 1209, 500, 29999),
-        ("t32_x16_y15_on1", 1208, 500, 29998),
+        ("t64_x16_y16_on8", 99, 500, 29999),
+        ("t32_x16_y15_on1", 101, 500, 29998),
     ],
 )
-def test_udp_encoder_decoder(format_type, payload_length, num_events, port):
+def test_udp_encoder_decoder(format_type, events_per_packet, num_events, port):
     """Test UDP encoder/decoder with random events."""
 
     dimensions = (640, 480)
@@ -53,7 +53,7 @@ def test_udp_encoder_decoder(format_type, payload_length, num_events, port):
         stream.to_udp(
             address,
             format=format_type,
-            payload_length=payload_length
+            events_per_packet=events_per_packet
         )
         time.sleep(0.1)  # Give receiver time to collect all packets
         stop_receiver.set()

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -1,0 +1,98 @@
+import pytest
+import threading
+import time
+
+import numpy as np
+import faery
+
+
+@pytest.mark.parametrize(
+    "format_type,payload_length,num_events,port",
+    [
+        ("t64_x16_y16_on8", 1209, 500, 29999),
+        ("t32_x16_y15_on1", 1208, 500, 29998),
+    ],
+)
+def test_udp_encoder_decoder(format_type, payload_length, num_events, port):
+    """Test UDP encoder/decoder with random events."""
+
+    dimensions = (640, 480)
+    address = ("localhost", port)
+
+    # Create random test events
+    test_events = np.zeros(num_events, dtype=faery.EVENTS_DTYPE)
+    test_events["t"] = np.arange(0, num_events * 1000, 1000, dtype=np.uint64)
+    test_events["x"] = np.random.randint(0, dimensions[0], num_events, dtype=np.uint16)
+    test_events["y"] = np.random.randint(0, dimensions[1], num_events, dtype=np.uint16)
+    test_events["on"] = np.random.randint(0, 2, num_events, dtype=bool)
+
+    received_events = []
+    stop_receiver = threading.Event()
+    receiver_exception = None
+
+    def receiver():
+        """Receive events from UDP."""
+        nonlocal receiver_exception
+        try:
+            stream = faery.events_stream_from_udp(
+                dimensions=dimensions,
+                address=address,
+                format=format_type
+            )
+            for events in stream:
+                received_events.append(events.copy())
+                if stop_receiver.is_set():
+                    break
+        except Exception as e:
+            receiver_exception = e
+
+    def sender():
+        """Send test events via UDP."""
+        time.sleep(0.2)  # Give receiver time to start listening
+        stream = faery.events_stream_from_array(test_events, dimensions)
+        stream.to_udp(
+            address,
+            format=format_type,
+            payload_length=payload_length
+        )
+        time.sleep(0.1)  # Give receiver time to collect all packets
+        stop_receiver.set()
+
+    # Start receiver and sender threads
+    receiver_thread = threading.Thread(target=receiver, daemon=True)
+    sender_thread = threading.Thread(target=sender, daemon=True)
+
+    receiver_thread.start()
+    sender_thread.start()
+
+    # Wait for completion with timeout
+    sender_thread.join(timeout=5)
+    receiver_thread.join(timeout=5)
+
+    # Verify no exceptions occurred
+    assert receiver_exception is None, f"Receiver exception: {receiver_exception}"
+
+    # Verify event count
+    all_received = np.concatenate(received_events)
+    assert len(all_received) == num_events, (
+        f"Expected {num_events} events, got {len(all_received)}"
+    )
+
+    # Verify event data matches (with consideration for timestamp wraparound in t32 format)
+    if format_type == "t64_x16_y16_on8":
+        # For t64 format, all fields should match exactly
+        assert np.array_equal(all_received["x"], test_events["x"]), "X coordinates don't match"
+        assert np.array_equal(all_received["y"], test_events["y"]), "Y coordinates don't match"
+        assert np.array_equal(all_received["on"], test_events["on"]), "Polarity doesn't match"
+        assert np.array_equal(all_received["t"], test_events["t"]), "Timestamps don't match"
+    else:
+        # For t32 format, timestamps are 32-bit so we check modulo 2^32
+        assert np.array_equal(all_received["x"], test_events["x"]), "X coordinates don't match"
+        assert np.array_equal(all_received["y"], test_events["y"]), "Y coordinates don't match"
+        assert np.array_equal(all_received["on"], test_events["on"]), "Polarity doesn't match"
+        # Check timestamps modulo 2^32
+        assert np.array_equal(
+            all_received["t"] & 0xFFFFFFFF,
+            test_events["t"] & 0xFFFFFFFF
+        ), "Timestamps don't match"
+


### PR DESCRIPTION
There are 3 changes in this PR. 

**1. Bug Fix**
* Fixes a bug in the UDP decoder (`udp_decoder.py`) for the t32 format by correctly extracting the `on` field from the packed `y+on` value and initializes the `offest` variable.

**2. Added UDP Unit Test**
* Added a test that transmits and receives randomly generated events on localhost for both UDP formats and validates the events, including wrapping for the 32-bit timestamp.

**3. Refactor UDP packetization interface:**
* Replaces the `payload_length` parameter with `events_per_packet` in the UDP encoder (`udp_encoder.py`). It seems to me that `payload_length` was really the number events per packet , so the I renamed the argument and removed the divisibility check like `assert payload_length % 8 == 0`.
* Changed the default value for new `events_per_packet` to 100 to be under the MTU for both formats. (Previous default value was above MacOS limit for UDP packet size 9216 bytes)
* It is worth noting that I seem to get better performance when exceeding the MTU and fragment packets. So perhaps its better to increase the default value?
* Another worthy note is that I occasionally run into UDP socket buffer overflow. Possible solution would be to drop packets when that happens.